### PR TITLE
Remove deletion of keychain credentials on mounting failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-2-10
+### Bug fixes
+- No longer delete keychain credentials when mounting a file share fails.
+
 ## [1.5.0] - 2025-1-29
 ### Features
 - Added the option in settings to restrict deletions after synchronization and manual deletions either entirely or to allow only deleting files or allowing deletion of both files and packages. (Issue #42)

--- a/Jamf Sync.xcodeproj/project.pbxproj
+++ b/Jamf Sync.xcodeproj/project.pbxproj
@@ -873,7 +873,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.jamfsync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -905,7 +905,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.jamfsync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/JamfSync/Model/FileShareDp.swift
+++ b/JamfSync/Model/FileShareDp.swift
@@ -130,7 +130,6 @@ class FileShareDp: DistributionPoint {
             }
         } catch {
             let serviceName = keychainHelper.fileShareServiceName(username: readWriteUsername, urlString: address)
-            try await keychainHelper.deleteKeychainItem(serviceName: serviceName, key: readWriteUsername)
             Task { @MainActor in
                 DataModel.shared.dpToPromptForPassword = self
                 DataModel.shared.shouldPromptForDpPassword = true


### PR DESCRIPTION
It turns out deleting the credentials from the keychain when mounting fails is not necessary and is a real pain for people when it fails due to network issues.