### PR TITLE
Addressed several GitHub issues (#16, #41, #63, #66, #72, #73) and up…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2025-9-5
+### Bug fixes
+- Added an API call that tells Jamf Pro to update the inventory after uploading to a Cloud DP (GitHub issue #16 "Packages uploaded through Jamf Sync sometimes do not install from a policy", #41 "Packages failing on install when syncing with 1.3.3+", #63 "The packages uploaded to S3 cloud DP via Jamf Sync couldn't be downloaded", #66 "Where does JamfSync store calculated Checksums for destination?").
+- Updated the recommended privileges to reference "Jamf Cloud Distribution Service Files" instead of "Jamf Content Distribution Service Files"(GitHub issue #72 "API Endpoint terminology changes"). 
+- Fixed an issue caused by a Jamf Pro change where checking to see if a distribution point had the ability to upload to a cloud instance would error out (GitHub issue #73 "Error connecting to JAMF Pro 11.20.0").
+
+### Enhancements
+- Updated some API calls from the deprecated version to the non-deprecated version.
+
 ## [1.5.1] - 2025-2-10
 ### Bug fixes
 - No longer delete keychain credentials when mounting a file share fails.

--- a/Jamf Sync.xcodeproj/project.pbxproj
+++ b/Jamf Sync.xcodeproj/project.pbxproj
@@ -873,7 +873,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.jamfsync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -905,7 +905,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jamf.jamfsync;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Jamf Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Jamf Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamf/Subprocess.git",
       "state" : {
-        "revision" : "be6506cc6b5240cba12aeeace94130f9e25cb296",
-        "version" : "3.0.5"
+        "revision" : "8fdaf02e66a46078d034a8bbab4fb74bf8067cdf",
+        "version" : "3.0.7"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     }
   ],

--- a/JamfSync/Model/DistributionPoint.swift
+++ b/JamfSync/Model/DistributionPoint.swift
@@ -168,6 +168,11 @@ class DistributionPoint: Identifiable {
         throw DistributionPointError.programError
     }
 
+    /// This is called on the destination distribution point after all files have been transferred.
+    /// If this is not overridden by a specific distrubtion point, then this does nothing.
+    func finalizeTransfer() async throws {
+    }
+
     /// Deletes a file from this distribution point.
     /// This function must be overridden by a child distribution point class.
     /// - Parameters:
@@ -397,6 +402,9 @@ class DistributionPoint: Identifiable {
         if let lastFile, lastFileTansferred {
             progress.finalProgressValues(totalBytesTransferred: lastFile.size ?? 0, currentTotalSizeTransferred: currentTotalSizeTransferred)
         }
+
+        try await dstDp.finalizeTransfer()
+
         inProgressDstDp = nil
         if someFilesFailed {
             if someFileSucceeded {

--- a/JamfSync/Model/FileShareDp.swift
+++ b/JamfSync/Model/FileShareDp.swift
@@ -38,23 +38,43 @@ class FileShareDp: DistributionPoint {
         super.init(name: name)
     }
 
-    init(JsonDpDetail: JsonDpDetail) {
-        self.jamfProId = JsonDpDetail.id ?? -1
-        self.address = JsonDpDetail.ip_address
-        self.isMaster = JsonDpDetail.is_master ?? false
-        if let connectionTypeString = JsonDpDetail.connection_type, let connectionType = ConnectionType(rawValue: connectionTypeString) {
+    init(jsonDpDetail: JsonDpDetail) {
+        self.jamfProId = jsonDpDetail.id ?? -1
+        self.address = jsonDpDetail.ip_address
+        self.isMaster = jsonDpDetail.is_master ?? false
+        if let connectionTypeString = jsonDpDetail.connection_type, let connectionType = ConnectionType(rawValue: connectionTypeString) {
             self.connectionType = connectionType
         } else {
             self.connectionType = .smb
         }
-        self.shareName = JsonDpDetail.share_name
-        self.workgroupOrDomain = JsonDpDetail.workgroup_or_domain
-        self.sharePort = JsonDpDetail.share_port
-        self.readOnlyUsername = JsonDpDetail.read_only_username
-        self.readOnlyPassword = nil // This would normally be from JsonDpDetail.read_only_password_sha256, but that's all asterisks
-        self.readWriteUsername = JsonDpDetail.read_write_username
-        self.readWritePassword = nil // This would normally be from JsonDpDetail.read_write_password_sha256, but that's all asterisks
-        super.init(name: JsonDpDetail.name ?? "")
+        self.shareName = jsonDpDetail.share_name
+        self.workgroupOrDomain = jsonDpDetail.workgroup_or_domain
+        self.sharePort = jsonDpDetail.share_port
+        self.readOnlyUsername = jsonDpDetail.read_only_username
+        self.readOnlyPassword = nil // This would normally be from jsonDpDetail.read_only_password_sha256, but that's all asterisks
+        self.readWriteUsername = jsonDpDetail.read_write_username
+        self.readWritePassword = nil // This would normally be from jsonDpDetail.read_write_password_sha256, but that's all asterisks
+        super.init(name: jsonDpDetail.name ?? "")
+        loadKeychainData()
+    }
+
+    init(jsonUapiDpDetail: JsonUapiDistributionPointDetail) {
+        self.jamfProId = Int(jsonUapiDpDetail.id ?? "-1") ?? -1
+        self.address = jsonUapiDpDetail.serverName
+        self.isMaster = jsonUapiDpDetail.principal ?? false
+        if let connectionTypeString = jsonUapiDpDetail.fileSharingConnectionType, let connectionType = ConnectionType(rawValue: connectionTypeString) {
+            self.connectionType = connectionType
+        } else {
+            self.connectionType = .smb
+        }
+        self.shareName = jsonUapiDpDetail.shareName
+        self.workgroupOrDomain = jsonUapiDpDetail.workgroup
+        self.sharePort = jsonUapiDpDetail.port
+        self.readOnlyUsername = jsonUapiDpDetail.readOnlyUsername
+        self.readOnlyPassword = nil
+        self.readWriteUsername = jsonUapiDpDetail.readWriteUsername
+        self.readWritePassword = nil
+        super.init(name: jsonUapiDpDetail.name ?? "")
         loadKeychainData()
     }
 

--- a/JamfSync/Model/JamfProInstance.swift
+++ b/JamfSync/Model/JamfProInstance.swift
@@ -303,7 +303,7 @@ class JamfProInstance: SavableItem {
         guard let url = url else { throw ServerCommunicationError.noToken }
         let tokenUrl: URL
         if useClientApi {
-            tokenUrl = url.appendingPathComponent("api/oauth/token")
+            tokenUrl = url.appendingPathComponent("api/v1/oauth/token")
         } else {
             tokenUrl = url.appendingPathComponent("api/v1/auth/token")
         }
@@ -425,11 +425,20 @@ class JamfProInstance: SavableItem {
         // Try to get the information for a non-existent file. If it returns a 500, then JCDS2 is not supported. If it returns 404, then it's good.
         let cloudUploadCapabilityUrl = url.appendingPathComponent("/api/v1/cloud-distribution-point/upload-capability")
 
-        let response = try await dataRequest(url: cloudUploadCapabilityUrl, httpMethod: "GET")
-        if let data = response.data {
-            let decoder = JSONDecoder()
-            if let jsonCloudDpUploadCapability = try? decoder.decode(JsonCloudDpUploadCapability.self, from: data) {
-                return jsonCloudDpUploadCapability.principalDistributionTechnology == true
+        do {
+            let response = try await dataRequest(url: cloudUploadCapabilityUrl, httpMethod: "GET")
+            if let data = response.data {
+                let decoder = JSONDecoder()
+                if let jsonCloudDpUploadCapability = try? decoder.decode(JsonCloudDpUploadCapability.self, from: data) {
+                    return jsonCloudDpUploadCapability.principalDistributionTechnology == true
+                }
+            }
+        } catch let ServerCommunicationError.dataRequestFailed(statusCode, message) {
+            if statusCode == 404 {
+                return false
+            } else {
+                // Rethrow the error
+                throw ServerCommunicationError.dataRequestFailed(statusCode: statusCode, message: message)
             }
         }
         return false
@@ -452,6 +461,30 @@ class JamfProInstance: SavableItem {
     }
 
     private func loadFileShares() async throws {
+        if await hasNewFileShareApi() {
+            try await loadFileSharesV1Api()
+        } else {
+            try await loadFileSharesLegacyApi()
+        }
+    }
+
+    private func hasNewFileShareApi() async -> Bool {
+        guard let jamfProVersion else { return false }
+        // If it's version 11.5 or greater, then it's supported
+        let versionParts = jamfProVersion.split(separator: ".")
+        if versionParts.count >= 2 {
+            if let majorVersion = Int(versionParts[0]), let minorVersion = Int(versionParts[1]) {
+                if majorVersion > 11 {
+                    return true
+                } else if majorVersion == 11 && minorVersion >= 6 {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private func loadFileSharesLegacyApi() async throws {
         guard let url = url else { throw ServerCommunicationError.noJamfProUrl }
         let fileSharesUrl = url.appendingPathComponent("JSSResource/distributionpoints")
 
@@ -472,6 +505,30 @@ class JamfProInstance: SavableItem {
         }
     }
 
+    private func loadFileSharesV1Api() async throws {
+        guard let url = url else { throw ServerCommunicationError.noJamfProUrl }
+        let fileSharesUrl = url.appendingPathComponent("api/v1/distribution-points").appending(queryItems: [URLQueryItem(name: "page", value: "0"), URLQueryItem(name: "page-size", value: "100")])
+
+        fileShares.removeAll()
+        do {
+            let response = try await dataRequest(url: fileSharesUrl, httpMethod: "GET")
+            if let data = response.data {
+                let decoder = JSONDecoder()
+                if let jsonDps = try? decoder.decode(JsonUapiDistributionPoint.self, from: data) {
+                    for dp in jsonDps.results {
+                        let fileShare = FileShareDp(jsonUapiDpDetail: dp)
+                        fileShare.jamfProInstanceId = id
+                        fileShare.jamfProInstanceName = name
+                       fileShares.append(fileShare)
+                    }
+                }
+            }
+        } catch let error {
+            LogManager.shared.logMessage(message: "Failed to get fileshare information from \(name): \(error)", level: .error)
+            throw error
+        }
+    }
+
     private func loadFileShare(fileShare: JsonDp) async throws {
         guard let url = url else { throw ServerCommunicationError.noJamfProUrl }
         let fileShareUrl = url.appendingPathComponent("JSSResource/distributionpoints/id/\(fileShare.id)")
@@ -481,7 +538,7 @@ class JamfProInstance: SavableItem {
                 do {
                     let decoder = JSONDecoder()
                     let jsonFileShare = try decoder.decode(JsonDpItem.self, from: data)
-                    let fileShare = FileShareDp(JsonDpDetail: jsonFileShare.distribution_point)
+                    let fileShare = FileShareDp(jsonDpDetail: jsonFileShare.distribution_point)
                     fileShare.jamfProInstanceId = id
                     fileShare.jamfProInstanceName = name
                    fileShares.append(fileShare)

--- a/JamfSync/Model/JamfProInstance.swift
+++ b/JamfSync/Model/JamfProInstance.swift
@@ -446,18 +446,7 @@ class JamfProInstance: SavableItem {
 
     private func hasUapiPackagesInterface() async throws -> Bool {
         guard let jamfProVersion else { return false }
-        // If it's version 11.5 or greater, then it's supported
-        let versionParts = jamfProVersion.split(separator: ".")
-        if versionParts.count >= 2 {
-            if let majorVersion = Int(versionParts[0]), let minorVersion = Int(versionParts[1]) {
-                if majorVersion > 11 {
-                    return true
-                } else if majorVersion == 11 && minorVersion >= 5 {
-                    return true
-                }
-            }
-        }
-        return false
+        return VersionInfo.versionIsAtLeast(version: jamfProVersion, major: 11, minor: 5)
     }
 
     private func loadFileShares() async throws {
@@ -470,18 +459,7 @@ class JamfProInstance: SavableItem {
 
     private func hasNewFileShareApi() async -> Bool {
         guard let jamfProVersion else { return false }
-        // If it's version 11.5 or greater, then it's supported
-        let versionParts = jamfProVersion.split(separator: ".")
-        if versionParts.count >= 2 {
-            if let majorVersion = Int(versionParts[0]), let minorVersion = Int(versionParts[1]) {
-                if majorVersion > 11 {
-                    return true
-                } else if majorVersion == 11 && minorVersion >= 6 {
-                    return true
-                }
-            }
-        }
-        return false
+        return VersionInfo.versionIsAtLeast(version: jamfProVersion, major: 11, minor: 6)
     }
 
     private func loadFileSharesLegacyApi() async throws {

--- a/JamfSync/Model/Jcds2Dp.swift
+++ b/JamfSync/Model/Jcds2Dp.swift
@@ -95,8 +95,7 @@ class Jcds2Dp: DistributionPoint, RenewTokenProtocol {
 
     override func finalizeTransfer() async throws {
         guard let jamfProInstanceId, let jamfProInstance = findJamfProInstance(id: jamfProInstanceId), let url = jamfProInstance.url else { throw ServerCommunicationError.noJamfProUrl }
-        // NOTE: This API will be deprecated after this ticket is completed: https://jamfpdd.atlassian.net/browse/JPXI-7661.
-        // It will most likely be /api/v1/cloud-distribution-point/refresh-inventory.
+        // NOTE: This API will be deprecated soon. It will most likely be /api/v1/cloud-distribution-point/refresh-inventory.
         let refreshInventoryUrl = url.appendingPathComponent("/api/v1/jcds/refresh-inventory")
 
         let _ = try await jamfProInstance.dataRequest(url: refreshInventoryUrl, httpMethod: "POST")

--- a/JamfSync/Model/Jcds2Dp.swift
+++ b/JamfSync/Model/Jcds2Dp.swift
@@ -93,6 +93,15 @@ class Jcds2Dp: DistributionPoint, RenewTokenProtocol {
         try await uploadToCloud(file: srcFile, moveFrom: localUrl, progress: progress)
     }
 
+    override func finalizeTransfer() async throws {
+        guard let jamfProInstanceId, let jamfProInstance = findJamfProInstance(id: jamfProInstanceId), let url = jamfProInstance.url else { throw ServerCommunicationError.noJamfProUrl }
+        // NOTE: This API will be deprecated after this ticket is completed: https://jamfpdd.atlassian.net/browse/JPXI-7661.
+        // It will most likely be /api/v1/cloud-distribution-point/refresh-inventory.
+        let refreshInventoryUrl = url.appendingPathComponent("/api/v1/jcds/refresh-inventory")
+
+        let _ = try await jamfProInstance.dataRequest(url: refreshInventoryUrl, httpMethod: "POST")
+    }
+
     override func deleteFile(file: DpFile, progress: SynchronizationProgress) async throws {
         guard let jamfProInstanceId, let jamfProInstance = findJamfProInstance(id: jamfProInstanceId), let url = jamfProInstance.url else { throw ServerCommunicationError.noJamfProUrl }
         let fileName = fileNameFromDpFile(file)

--- a/JamfSync/Model/JsonObjects.swift
+++ b/JamfSync/Model/JsonObjects.swift
@@ -172,6 +172,33 @@ struct JsonUapiPackageDetail: Codable {
     }
 }
 
+struct JsonUapiDistributionPoint: Decodable {
+    let totalCount: Int
+    let results: [JsonUapiDistributionPointDetail]
+}
+
+struct JsonUapiDistributionPointDetail: Codable {
+    let id: String?
+    let name: String?
+    let serverName: String?
+    var fileSharingConnectionType: String?
+    let shareName: String?
+    let workgroup: String?
+    let port: Int?
+    var readWriteUsername: String?
+    var readOnlyUsername: String?
+    var principal: Bool?
+    var backupDistributionPointId: String?
+    var sshUsername: String?
+    var localPathToShare: String?
+    var httpsEnabled: Bool?
+    let httpsPort: Int?
+    var httpsContext: String?
+    var httpsSecurityType: String?
+    var httpsUsername: String?
+    var enableLoadBalancing: Bool?
+}
+
 struct JsonUapiAddPackageResult: Decodable {
     let id: String
     let href: String?

--- a/JamfSync/UI/JamfProServerView.swift
+++ b/JamfSync/UI/JamfProServerView.swift
@@ -20,8 +20,8 @@ struct JamfProServerView: View {
     @State var testResultMessage = ""
     @State var testInProgress = false
     let keychainHelper = KeychainHelper()
-    let recommendedClientApiPrivileges = "Update Packages, Jamf Packages Action, Read Cloud Services Settings, Read Jamf Content Distribution Server Files, Create Packages, Delete Packages, Read Cloud Distribution Point, Update Cloud Distribution Point, Create Jamf Content Distribution Server Files, Read Distribution Points, Read Packages, Delete Jamf Content Distribution Server Files"
-    let recommendedCapiPrivileges = "Packages (Create, Read, Update, Delete), Categories (Read), File share distribution points (Read), Jamf Content Distribution Server Files (Create, Read, Delete)"
+    let recommendedClientApiPrivileges = "Update Packages, Jamf Packages Action, Read Cloud Services Settings, Read Jamf Cloud Distribution Service Files, Create Packages, Delete Packages, Read Cloud Distribution Point, Update Cloud Distribution Point, Create Jamf Cloud Distribution Service Files, Read Distribution Points, Read Packages, Delete Jamf Cloud Distribution Service Files"
+    let recommendedCapiPrivileges = "Packages (Create, Read, Update, Delete), Categories (Read), File share distribution points (Read), Jamf Cloud Distribution Service Files (Create, Read, Delete)"
 
     var body: some View {
         VStack(spacing: 10) {

--- a/JamfSync/Utility/VersionInfo.swift
+++ b/JamfSync/Utility/VersionInfo.swift
@@ -10,4 +10,18 @@ class VersionInfo {
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") ?? ""
         return "Version: \(version) (\(build))"
     }
+
+    static func versionIsAtLeast(version: String, major: Int, minor: Int) -> Bool {
+        let versionParts = version.split(separator: ".")
+        if versionParts.count >= 2 {
+            if let majorVersion = Int(versionParts[0]), let minorVersion = Int(versionParts[1]) {
+                if majorVersion > major {
+                    return true
+                } else if majorVersion == major && minorVersion >= minor {
+                    return true
+                }
+            }
+        }
+        return false
+    }
 }

--- a/JamfSyncTests/FileShareDpTests.swift
+++ b/JamfSyncTests/FileShareDpTests.swift
@@ -39,7 +39,7 @@ final class FileShareDpTests: XCTestCase {
         let jsonDpDetail = JsonDpDetail()
 
         // When
-        let fileShareDp = FileShareDp(JsonDpDetail: jsonDpDetail)
+        let fileShareDp = FileShareDp(jsonDpDetail: jsonDpDetail)
 
         // Then
         XCTAssertEqual(fileShareDp.name, "")
@@ -71,7 +71,7 @@ final class FileShareDpTests: XCTestCase {
         jsonDpDetail.workgroup_or_domain = "Workgroup"
 
         // When
-        let fileShareDp = FileShareDp(JsonDpDetail: jsonDpDetail)
+        let fileShareDp = FileShareDp(jsonDpDetail: jsonDpDetail)
 
         // Then
         XCTAssertEqual(fileShareDp.name, "FileShareDp")
@@ -103,7 +103,7 @@ final class FileShareDpTests: XCTestCase {
         jsonDpDetail.workgroup_or_domain = "Workgroup"
 
         // When
-        let fileShareDp = FileShareDp(JsonDpDetail: jsonDpDetail)
+        let fileShareDp = FileShareDp(jsonDpDetail: jsonDpDetail)
 
         // Then
         XCTAssertEqual(fileShareDp.name, "FileShareDp")
@@ -135,7 +135,7 @@ final class FileShareDpTests: XCTestCase {
         jsonDpDetail.workgroup_or_domain = "Workgroup"
 
         // When
-        let fileShareDp = FileShareDp(JsonDpDetail: jsonDpDetail)
+        let fileShareDp = FileShareDp(jsonDpDetail: jsonDpDetail)
 
         // Then
         XCTAssertEqual(fileShareDp.name, "FileShareDp")


### PR DESCRIPTION
…dated some deprecated api calls to the non-deprecated ones (api/v1/oauth/token and api/v1/distribution-points)

### Bug fixes
- Added an API call that tells Jamf Pro to update the inventory after uploading to a Cloud DP (GitHub issue #16 "Packages uploaded through Jamf Sync sometimes do not install from a policy", #41 "Packages failing on install when syncing with 1.3.3+", #63 "The packages uploaded to S3 cloud DP via Jamf Sync couldn't be downloaded", #66 "Where does JamfSync store calculated Checksums for destination?").
- Updated the recommended privileges to reference "Jamf Cloud Distribution Service Files" instead of "Jamf Content Distribution Service Files"(GitHub issue #72 "API Endpoint terminology changes"). 
- Fixed an issue caused by a Jamf Pro change where checking to see if a distribution point had the ability to upload to a cloud instance would error out (GitHub issue #73 "Error connecting to JAMF Pro 11.20.0").

### Enhancements
- Updated some API calls from the deprecated version to the non-deprecated version.
